### PR TITLE
Create 2115_Find_All_Possible_Recipes_from_Given_Supplies.cs

### DIFF
--- a/2115_Find_All_Possible_Recipes_from_Given_Supplies.cs
+++ b/2115_Find_All_Possible_Recipes_from_Given_Supplies.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+public class Solution {
+    public IList<string> FindAllRecipes(string[] recipes, IList<IList<string>> ingredients, string[] supplies) {
+        // Mapa de recetas a sus ingredientes
+        Dictionary<string, IList<string>> recipeMap = new Dictionary<string, IList<string>>();
+        // Conjunto de suministros iniciales
+        HashSet<string> supplySet = new HashSet<string>(supplies);
+        // Conjunto para almacenar las recetas que se pueden crear
+        HashSet<string> canMake = new HashSet<string>();
+        // Estado de las recetas: 0 = no visitada, 1 = visitando, 2 = visitada
+        Dictionary<string, int> state = new Dictionary<string, int>();
+
+        // Llenar el mapa de recetas
+        for (int i = 0; i < recipes.Length; i++) {
+            recipeMap[recipes[i]] = ingredients[i];
+            state[recipes[i]] = 0; // Inicialmente, todas las recetas están no visitadas
+        }
+
+        // Función para verificar si se puede hacer una receta
+        bool CanMakeRecipe(string recipe) {
+            if (state[recipe] == 1) return false; // Ciclo detectado
+            if (state[recipe] == 2) return true; // Ya se puede hacer
+
+            state[recipe] = 1; // Marcar como visitando
+
+            // Obtener los ingredientes necesarios
+            foreach (var ingredient in recipeMap[recipe]) {
+                // Si el ingrediente es un suministro, continuar
+                if (supplySet.Contains(ingredient)) {
+                    continue;
+                }
+                // Si el ingrediente es una receta, verificar si se puede hacer
+                if (!recipeMap.ContainsKey(ingredient) || !CanMakeRecipe(ingredient)) {
+                    state[recipe] = 0; // Marcar como no visitada
+                    return false; // No se puede hacer esta receta
+                }
+            }
+
+            // Si se pueden hacer todos los ingredientes, se puede hacer la receta
+            state[recipe] = 2; // Marcar como visitada
+            canMake.Add(recipe);
+            return true;
+        }
+
+        // Verificar cada receta
+        foreach (var recipe in recipes) {
+            CanMakeRecipe(recipe);
+        }
+
+        // Convertir el conjunto de recetas que se pueden hacer a una lista
+        return new List<string>(canMake);
+    }
+}


### PR DESCRIPTION
El error que estás experimentando, KeyNotFoundException, indica que el código está intentando acceder a una clave en el diccionario que no existe. En este caso, parece que el problema ocurre cuando se verifica si un ingrediente es un suministro o una receta.

El problema específico en el caso que mencionas es que el código intenta verificar si un ingrediente (en este caso, "flour") está en el diccionario recipeMap, pero "flour" no es una receta, por lo que no debería estar en ese diccionario. Debemos asegurarnos de que solo verifiquemos si un ingrediente es una receta si no está en el conjunto de suministros.

Cambios realizados:
Verificación de ingredientes: Antes de intentar acceder a recipeMap para un ingrediente, primero verificamos si el ingrediente está en supplySet. Si es así, simplemente continuamos con el siguiente ingrediente.

Verificación de recetas: Solo intentamos verificar si un ingrediente es una receta si no está en supplySet. Esto evita el acceso a claves que no existen en el diccionario y previene el error KeyNotFoundException.